### PR TITLE
Fix @pjsekai-overlay.obj installation

### DIFF
--- a/pkg/pjsekaioverlay/installCheck.go
+++ b/pkg/pjsekaioverlay/installCheck.go
@@ -33,9 +33,9 @@ func TryInstallObject() bool {
 	aviutlPath = filepath.Dir(aviutlProcess.Fullpath)
 	var exeditRoot string
 	if _, err := os.Stat(filepath.Join(aviutlPath, "exedit.auf")); os.IsNotExist(err) {
-		exeditRoot = filepath.Join(aviutlPath)
-	} else if _, err := os.Stat(filepath.Join(aviutlPath, "Plugins", "exedit.auf")); os.IsNotExist(err) {
 		exeditRoot = filepath.Join(aviutlPath, "Plugins")
+	} else if _, err := os.Stat(filepath.Join(aviutlPath, "Plugins", "exedit.auf")); os.IsNotExist(err) {
+		exeditRoot = filepath.Join(aviutlPath)
 	} else {
 		return false
 	}


### PR DESCRIPTION
Currently, pjsekai-overlay checks the location of `exedit.auf` with the following conditions:
- If `exedit.auf` doesn't exist in the base AviUtl path -> create @pjsekai-overlay.obj in base path
- If `exedit.auf` doesn't exist in the plugins folder -> create @pjsekai-overlay.obj in the plugins folder

It should be the other way around. I tried changing `os.IsNotExist()` to `os.IsExist()` but that broke it, so I swapped the `exeditRoot` instead.