### PR TITLE
Don't separate composer and vocals if there's more than 2 slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,12 +173,12 @@ func origMain(isOptionSpecified bool) {
 
 	fmt.Print("exoファイルを生成中... ")
 
-	artists_slice := []string{chart.Artists, "？"}
-	if chartSource.Id == "chart_cyanvas" {
-		artists_slice = strings.Split(chart.Artists, " / ")
+	composer_vocals := []string{chart.Artists, "？"}
+	if separate_attempt := strings.Split(chart.Artists, " / "); chartSource.Id == "chart_cyanvas" && len(separate_attempt) <= 2 {
+		composer_vocals = separate_attempt
 	}
 
-	artists := fmt.Sprintf("作詞：？    作曲：%s    編曲：？\r\nVo：%s   譜面作成：%s", artists_slice[0], artists_slice[1], chart.Author)
+	artists := fmt.Sprintf("作詞：？    作曲：%s    編曲：？\r\nVo：%s   譜面作成：%s", composer_vocals[0], composer_vocals[1], chart.Author)
 
 	err = pjsekaioverlay.WriteExoFiles(assets, formattedOutDir, chart.Title, artists)
 


### PR DESCRIPTION
There is a flaw that I overlooked with my previous PR. If there are `/` in the chart's Composer and Vocal, it won't work correctly. I still think that automatically separating the two is a nice thing to have, so until I figure out a solution (if there is any), I made it revert to previous behavior if there are more than 2 `/`. I apologize.\
![oversight](https://github.com/sevenc-nanashi/pjsekai-overlay/assets/46954143/93eddc95-7526-4c95-a49a-b9cc96f8a0ac)
