### PR TITLE
Adjust score rank border to be based on level rating instead of a constant number

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/google/go-github/v57/github"
 	"github.com/sevenc-nanashi/pjsekai-overlay/pkg/pjsekaioverlay"
+	"github.com/sevenc-nanashi/pjsekai-overlay/pkg/sonolus"
 	"github.com/srinathh/gokilo/rawmode"
 	"golang.org/x/sys/windows"
 )

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func origMain(isOptionSpecified bool) {
 
 	fmt.Print("pedファイルを生成中... ")
 
-	err = pjsekaioverlay.WritePedFile(scoreData, assets, apCombo, filepath.Join(formattedOutDir, "data.ped"))
+	err = pjsekaioverlay.WritePedFile(scoreData, assets, apCombo, filepath.Join(formattedOutDir, "data.ped"), sonolus.LevelInfo{Rating: chart.Rating})
 
 	if err != nil {
 		fmt.Println(color.RedString(fmt.Sprintf("失敗：%s", err.Error())))

--- a/pkg/pjsekaioverlay/ped.go
+++ b/pkg/pjsekaioverlay/ped.go
@@ -223,24 +223,17 @@ func WritePedFile(frames []PedFrame, assets string, ap bool, path string, levelI
 		scoreX := 0.0
 
 		// rank
+		if rating < 5 {
+			rating = 5
+		} else if rating > 40 {
+			rating = 40
+		}
+
 		rankBorder := 1200000 + (rating-5)*4100
 		rankS := 1040000 + (rating-5)*5200
 		rankA := 840000 + (rating-5)*4200
 		rankB := 400000 + (rating-5)*2000
 		rankC := 20000 + (rating-5)*100
-		if rating < 5 {
-			rankBorder = 1200000
-			rankS = 1040000
-			rankA = 840000
-			rankB = 400000
-			rankC = 20000
-		} else if rating > 40 {
-			rankBorder = 1343500
-			rankS = 1222000
-			rankA = 987000
-			rankB = 470000
-			rankC = 23500
-		}
 
 		// bar
 		if score >= rankBorder {

--- a/pkg/pjsekaioverlay/ped.go
+++ b/pkg/pjsekaioverlay/ped.go
@@ -199,7 +199,7 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 func WritePedFile(frames []PedFrame, assets string, ap bool, path string) error {
 	file, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("ファイルの作成に失敗しました (Failed to create file.) [%s]", err)
+		return fmt.Errorf("ファイルの作成に失敗しました（%s）", err)
 	}
 	defer file.Close()
 

--- a/pkg/pjsekaioverlay/ped.go
+++ b/pkg/pjsekaioverlay/ped.go
@@ -28,7 +28,7 @@ var WEIGHT_MAP = map[string]float64{
 	"Stage":          0,
 
 	"NormalTapNote":   1,
-	"CriticalTapNote": 3,
+	"CriticalTapNote": 2,
 
 	"NormalFlickNote":   1,
 	"CriticalFlickNote": 3,
@@ -44,11 +44,11 @@ var WEIGHT_MAP = map[string]float64{
 
 	"HiddenSlideTickNote":   0,
 	"NormalSlideTickNote":   0.1,
-	"CriticalSlideTickNote": 0.1,
+	"CriticalSlideTickNote": 0.2,
 
 	"IgnoredSlideTickNote":          0.1,
 	"NormalAttachedSlideTickNote":   0.1,
-	"CriticalAttachedSlideTickNote": 0.1,
+	"CriticalAttachedSlideTickNote": 0.2,
 
 	"NormalSlideConnector":   0,
 	"CriticalSlideConnector": 0,
@@ -65,7 +65,7 @@ var WEIGHT_MAP = map[string]float64{
 	"CriticalSlotGlowEffect": 0,
 
 	"NormalTraceNote":   0.1,
-	"CriticalTraceNote": 0.1,
+	"CriticalTraceNote": 0.2,
 
 	"NormalTraceSlotEffect":     0,
 	"NormalTraceSlotGlowEffect": 0,
@@ -74,14 +74,14 @@ var WEIGHT_MAP = map[string]float64{
 	"DamageSlotEffect":     0,
 	"DamageSlotGlowEffect": 0,
 
-	"NormalTraceFlickNote":         0.5,
-	"CriticalTraceFlickNote":       0.5,
-	"NonDirectionalTraceFlickNote": 0.5,
+	"NormalTraceFlickNote":         1,
+	"CriticalTraceFlickNote":       3,
+	"NonDirectionalTraceFlickNote": 1,
 
 	"NormalTraceSlideStartNote":   0.1,
 	"NormalTraceSlideEndNote":     0.1,
-	"CriticalTraceSlideStartNote": 0.1,
-	"CriticalTraceSlideEndNote":   0.1,
+	"CriticalTraceSlideStartNote": 0.2,
+	"CriticalTraceSlideEndNote":   0.2,
 
 	"TimeScaleGroup":  0,
 	"TimeScaleChange": 0,
@@ -133,6 +133,7 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 	frames = append(frames, PedFrame{Time: 0, Score: 0})
 	bpmChanges := ([]BpmChange{})
 	levelFax := float64(rating-5)*0.005 + 1
+	comboFax := 1.0
 
 	score := 0
 	entityCounter := 0
@@ -166,6 +167,12 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 	for _, entity := range noteEntities {
 		weight := WEIGHT_MAP[entity.Archetype]
 		entityCounter += 1
+		if entityCounter%100 == 0 {
+			comboFax += 0.01
+		}
+		if comboFax > 1.1 {
+			comboFax = 1.1
+		}
 
 		score += int(
 			(float64(power) / weightedNotesCount) * // Team power / weighted notes count
@@ -173,7 +180,7 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 				weight * // Note weight
 				1 * // Judge weight (Always 1)
 				levelFax * // Level fax
-				(float64(entityCounter/100)/100 + 1) * // Combo fax
+				comboFax * // Combo fax
 				1, // Skill fax (Always 1)
 		)
 		beat, err := getValueFromData(entity.Data, "#BEAT")
@@ -192,7 +199,7 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 func WritePedFile(frames []PedFrame, assets string, ap bool, path string) error {
 	file, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("ファイルの作成に失敗しました（%s）", err)
+		return fmt.Errorf("ファイルの作成に失敗しました (Failed to create file.) [%s]", err)
 	}
 	defer file.Close()
 

--- a/pkg/pjsekaioverlay/ped.go
+++ b/pkg/pjsekaioverlay/ped.go
@@ -196,7 +196,7 @@ func CalculateScore(levelInfo sonolus.LevelInfo, levelData sonolus.LevelData, po
 	return frames
 }
 
-func WritePedFile(frames []PedFrame, assets string, ap bool, path string) error {
+func WritePedFile(frames []PedFrame, assets string, ap bool, path string, levelInfo sonolus.LevelInfo) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("ファイルの作成に失敗しました（%s）", err)
@@ -211,6 +211,7 @@ func WritePedFile(frames []PedFrame, assets string, ap bool, path string) error 
 	writer.Write([]byte(fmt.Sprintf("u|%d\n", time.Now().Unix())))
 
 	lastScore := 0
+	rating := levelInfo.Rating
 	for i, frame := range frames {
 		score := frame.Score
 		frameScore := score - lastScore
@@ -220,24 +221,46 @@ func WritePedFile(frames []PedFrame, assets string, ap bool, path string) error 
 
 		rank := "n"
 		scoreX := 0.0
-		if score >= 1300000 {
+
+		// rank
+		rankBorder := 1200000 + (rating-5)*4100
+		rankS := 1040000 + (rating-5)*5200
+		rankA := 840000 + (rating-5)*4200
+		rankB := 400000 + (rating-5)*2000
+		rankC := 20000 + (rating-5)*100
+		if rating < 5 {
+			rankBorder = 1200000
+			rankS = 1040000
+			rankA = 840000
+			rankB = 400000
+			rankC = 20000
+		} else if rating > 40 {
+			rankBorder = 1343500
+			rankS = 1222000
+			rankA = 987000
+			rankB = 470000
+			rankC = 23500
+		}
+
+		// bar
+		if score >= rankBorder {
 			rank = "s"
 			scoreX = 357
-		} else if score >= 1165000 {
+		} else if score >= rankS {
 			rank = "s"
-			scoreX = float64((score-1165000))/(1300000-1165000)*37 + 320
-		} else if score >= 940000 {
+			scoreX = (float64((score-rankS))/float64((rankBorder-rankS)))*37 + 320
+		} else if score >= rankA {
 			rank = "a"
-			scoreX = float64((score-940000))/(1165000-940000)*53 + 267
-		} else if score >= 434000 {
+			scoreX = (float64((score-rankA))/float64((rankS-rankA)))*53 + 267
+		} else if score >= rankB {
 			rank = "b"
-			scoreX = float64((score-434000))/(940000-434000)*53 + 215
-		} else if score >= 21500 {
+			scoreX = (float64((score-rankB))/float64((rankA-rankB)))*53 + 215
+		} else if score >= rankC {
 			rank = "c"
-			scoreX = float64((score-21500))/(434000-21500)*54 + 161
-		} else if score >= 0 {
+			scoreX = (float64((score-rankC))/float64((rankB-rankC)))*54 + 161
+		} else {
 			rank = "d"
-			scoreX = float64(score) / 21500 * 160
+			scoreX = (float64(score) / float64(rankC)) * 160
 		}
 
 		writer.Write([]byte(fmt.Sprintf("s|%f:%d:%d:%f:%s:%d\n", frame.Time, score, frameScore, scoreX/357, rank, i)))


### PR DESCRIPTION
- Adjust score rank border to be based on level rating instead of a constant number [(learn more on how it works)](https://github.com/Sekai-World/sekai-master-db-diff/blob/967927ecbfa49e409aa51fc466589e15e5b6e551/playLevelScores.json#L1923)
   - `rankBorder` refers to maximum score to fill up the whole score bar
   - `rating` refers to the level rating from the inputted chart data
```
rankBorder := 1200000 + (rating-5)*4100
rankS := 1040000 + (rating-5)*5200
rankA := 840000 + (rating-5)*4200
rankB := 400000 + (rating-5)*2000
rankC := 20000 + (rating-5)*100
```